### PR TITLE
Fix shadowing path

### DIFF
--- a/src/@narative/gatsby-theme-novela/components/Navigation/Navigation.Header.js
+++ b/src/@narative/gatsby-theme-novela/components/Navigation/Navigation.Header.js
@@ -97,7 +97,7 @@ const NavigationHeader = () => {
     const prev = localStorage.getItem("previousPath");
     const previousPathWasHomepage =
       prev === (rootPath || basePath) || (prev && prev.includes("/page/"));
-    const isNotPaginated = !location.pathname.includes("/page/");
+    const isNotPaginated = !window.location.pathname.includes("/page/");
 
     setShowBackArrow(
       previousPathWasHomepage && isNotPaginated && width <= phablet,

--- a/src/@narative:gatsby-theme-novela/components/Navigation/index.js
+++ b/src/@narative:gatsby-theme-novela/components/Navigation/index.js
@@ -1,1 +1,0 @@
-import './Navigation.Header.js'


### PR DESCRIPTION
This should fix the shadowing issue. 

It wanted `@narative/gatsby-theme-novela` instead of `@narative:gatsby-theme-novela`, which admittedly does not follow the repo structure. Had to track down another person's site to find it.

Also threw in a minor fix for the location reference React errored on once I got it working. Feel free to ignore that or change it differently if you'd prefer.